### PR TITLE
nicer printing for lazy seqs (likely other objects as well)

### DIFF
--- a/spec/speclj/should_spec.clj
+++ b/spec/speclj/should_spec.clj
@@ -33,6 +33,10 @@
   (it "nil is printed as 'nil' instead of blank"
     (should= (str "Expected: <1>" endl "     got: nil (using =)") (failure-message (should= 1 nil))))
 
+  (it "prints lazy seqs nicely"
+    (should= (str "Expected: <(1 2 3)>" endl "     got: <(3 2 1)> (using =)")
+             (failure-message (should= '(1 2 3) (concat '(3) '(2 1))))))
+
   (it "should_not= tests inequality"
     (should-pass! (should-not= 1 2))
     (should-fail! (should-not= 1 1)))
@@ -74,7 +78,7 @@
     (should-fail! (should-throw Exception "My message" (throw (Exception. "Not my message"))))
     (should-fail! (should-throw Exception "My message" (throw (Error. "My message"))))
     (should-fail! (should-throw Exception "My message" (+ 1 1)))
-    (should= (str "Expected exception message didn't match" endl "Expected: <My message>" endl "     got: <Not my message> (using =)")
+    (should= (str "Expected exception message didn't match" endl "Expected: <\"My message\">" endl "     got: <\"Not my message\"> (using =)")
              (failure-message (should-throw Exception "My message" (throw (Exception. "Not my message"))))))
 
   (it "should-not-throw tests that nothing was thrown"

--- a/src/speclj/core.clj
+++ b/src/speclj/core.clj
@@ -73,7 +73,7 @@
       with-component#)))
 
 (defn -to-s [thing]
-  (if (nil? thing) "nil" (str "<" thing ">")))
+  (if (nil? thing) "nil" (str "<" (pr-str thing) ">")))
 
 (defmacro should
   "Asserts the truthy-ness of a form"


### PR DESCRIPTION
I noticed when trying out speclj that a failing test of mine was showing something like this:

```
Expected: <(1 2 3)>
     got: <clojure.lang.LazySeq@7842> (using =)
```

Using `pr-str` on the thing being evaluated gives a more correct answer. I needed to change an existing spec to make this change, but I think that one is also a correction rather than a problem: adds quotes to the should-throw error message for when the Exception message differs.  Since that value is a string, it makes sense to have it quoted inside the angle brackets (<"Not my message"> instead of <Not my message>).

Thoughts?

Colin
