### PR TITLE
Here's the change to remove hidden files from clj-files-in function

### DIFF
--- a/src/fresh/core.clj
+++ b/src/fresh/core.clj
@@ -5,7 +5,7 @@
 ; Copied from https://github.com/slagyr/fresh so speclj can remain without dependencies.
 ;
 ; *********************************************************************************************************************
-
+  
 (ns fresh.core
   (:use
     [clojure.java.io :only (file)])
@@ -19,7 +19,8 @@
   "Returns a seq of all clojure source files contained in the given directories."
   [& dirs]
   (let [files (reduce #(into %1 (file-seq (file %2))) [] dirs)]
-    (filter #(re-matches clj-file-regex (.getName %)) files)))
+    (filter #(re-matches clj-file-regex (.getName %))
+            (remove #(.isHidden %) files))))
 
 ;; Resolving ns names ---------------------------------------------------------------------------------------------------
 ;


### PR DESCRIPTION
Simple enough change.   

Again, the reason is because Emacs creates lock files (not temp files) in the directory and it was causing autotest to spin its wheels when editing a file.  It could be made to optionally remove them but it seems reasonable enough to never want hidden files.
