### PR TITLE
Allow chaining of autotest and additional formatters.

### DIFF
--- a/spec/speclj/main_spec.clj
+++ b/spec/speclj/main_spec.clj
@@ -76,6 +76,11 @@
       (should= "vigilant" (:runner options))
       (should= ["documentation"] (:reporters options))))
 
+  (it "allows adding extra reporters when using autotest"
+    (let [options (parse-args "-a" "-f" "progress")]
+      (should= "vigilant" (:runner options))
+      (should= ["documentation" "progress"] (sort (:reporters options)))))
+
   (it "parses the --color switch"
     (should= nil (:color (parse-args "")))
     (should= "on" (:color (parse-args "--color")))

--- a/src/speclj/main.clj
+++ b/src/speclj/main.clj
@@ -46,8 +46,8 @@
 
 (defn- resolve-aliases [options]
   (cond
-    (:format options) (recur (dissoc (assoc options :reporter (:format options)) :format))
-    (:autotest options) (recur (dissoc (assoc options :runner "vigilant" :reporters (conj (:format options) "documentation")) :autotest))
+    (:format options) (recur (dissoc (assoc options :reporter (concat (:reporter options) (:format options))) :format))
+    (:autotest options) (recur (dissoc (assoc options :runner "vigilant" :reporter (concat (:reporter options) ["documentation"])) :autotest))
     (:reporter options) (recur (dissoc (assoc options :reporters (map resolve-reporter-alias (:reporter options))) :reporter))
     (= "s" (:runner options)) (recur (assoc options :runner "standard"))
     (= "v" (:runner options)) (recur (assoc options :runner "vigilant"))


### PR DESCRIPTION
This should allow speclj growl to use: lein spec -a -f growl
