### PR TITLE
launch speclj process inside of (:root project) instead of '.'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ classes
 out
 *.jar
 .idea
+*.lein-deps-sum

--- a/src/leiningen/spec.clj
+++ b/src/leiningen/spec.clj
@@ -1,6 +1,6 @@
 (ns leiningen.spec
   (:use
-;    [leiningen.compile :only [eval-in-project]]
+    [clojure.java.io :only [file]]
     [leiningen.classpath :only [get-classpath-string]])
   (:import
     [java.io BufferedInputStream]))
@@ -12,10 +12,10 @@
         (.write out b)
         (recur (.read input))))))
 
-(defn- java [jvm-args main-class args]
+(defn- java [jvm-args main-class args working-directory]
   (let [java-exe (str (System/getProperty "java.home") "/bin/java")
         command (into-array (concat [java-exe] jvm-args [main-class] args))
-        process (.exec (Runtime/getRuntime) command)
+        process (.exec (Runtime/getRuntime) command nil (file working-directory))
         output (BufferedInputStream. (.getInputStream process))
         output-thread (Thread. #(copy-bytes output System/out))
         error (BufferedInputStream. (.getErrorStream process))
@@ -31,4 +31,4 @@
   (let [speclj-args (cons "-c" args)
         classpath (get-classpath-string project)
         jvm-args ["-cp" classpath "-Dspeclj.invocation=lein spec"]]
-    (java jvm-args "speclj.main" speclj-args)))
+    (java jvm-args "speclj.main" speclj-args (:root project))))


### PR DESCRIPTION
Added a fix in the leiningen plugin that starts the speclj process inside of the given project's directory instead of in ".". This allows for usage with the lein-sub plugin.
