### PR TITLE
Updated the dependency declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You will need [Leiningen](https://github.com/technomancy/leiningen) version 1.4 
 
 Include speclj in your `:dev-dependencies` and change the `:test-path` to `"spec/"`
 
-	:dev-dependencies [[speclj "1.2.0"]]
+	:dev-dependencies [[speclj "2.0.0"]]
 	:test-path "spec/"
 	
 ## Manual installation	


### PR DESCRIPTION
speclj 1.2.0 doesn't work with either clojure 1.3 or 1.4
