### PR TITLE
Upgrade to work with lein2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 *.jar
 .idea
 *.lein-deps-sum
+target

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(require 'speclj.version)
+(load-file "src/speclj/version.clj")
 
 (defproject speclj speclj.version/string
   :description "speclj: Pronounced 'speckle', is a Behavior Driven Development framework for Clojure."
@@ -6,11 +6,13 @@
             :url "file://LICENSE"
             :distribution :repo
             :comments "Copyright © 2011 Micah Martin All Rights Reserved."}
-  :dependencies [[org.clojure/clojure "1.4.0-alpha3"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [fresh "1.0.2"]
                  [mmargs "1.2.0"]]
-  :dev-dependencies []
-  :test-path "spec/"
-  :java-source-path "src/"
+  :eval-in-leiningen true
+  :test-path "spec"
+  :test-paths ["spec"]
+  :java-source-path "src"
+  :java-source-paths ["src"]
   :uberjar-exclusions [#"^clojure/.*"]
   )

--- a/src/leiningen/spec.clj
+++ b/src/leiningen/spec.clj
@@ -1,7 +1,6 @@
 (ns leiningen.spec
   (:use
-    [clojure.java.io :only [file]]
-    [leiningen.classpath :only [get-classpath-string]])
+    [clojure.java.io :only [file]])
   (:import
     [java.io BufferedInputStream]))
 
@@ -27,8 +26,25 @@
     (.join error-thread 1000)
     (.exitValue process)))
 
+(defn- compute-classpath-string [project]
+  (clojure.string/join java.io.File/pathSeparatorChar
+        ((or (ns-resolve (create-ns 'leiningen.classpath) 'get-classpath)
+             (ns-resolve (create-ns 'leiningen.core.classpath) 'get-classpath))
+          project)))
+
+(defn- prepare [project]
+  (try
+    (require 'leiningen.core.eval)
+    ((ns-resolve 'leiningen.core.eval 'prep)
+       project)
+    (catch Exception e
+      (require 'leiningen.classpath
+               'leiningen.compile)
+      ((ns-resolve 'leiningen.compile 'prep) project false))))
+
 (defn spec [project & args]
+  (prepare project)
   (let [speclj-args (cons "-c" args)
-        classpath (get-classpath-string project)
+        classpath (compute-classpath-string project)
         jvm-args ["-cp" classpath "-Dspeclj.invocation=lein spec"]]
     (java jvm-args "speclj.main" speclj-args (:root project))))


### PR DESCRIPTION
Things are still working just fine with lein1, as far as I can tell.

Bumped the clojure dependency to 1.4.0 final.

Removed the need to run deps or compile before lein spec on either lein version.

require in project.clj had to be replaced because of lein2's classpath separation. I guess the cleaner/more preferred way to hook into versioning is to let project.clj be the source of record, and get that info from leiningen as we [figured out in reply](https://github.com/trptcolin/reply/pull/65). I'm hoping @borkdude, who wrote the code there, will extract a library, or at worst give me permission to, and then we could potentially use it here. Not a huge deal though.

One last thing: looks like the current speclj version is a non-snapshot - I didn't want to bump it as part of this pull request, but it should probably be bumped up.
