### PR TITLE
Fixes exit code warning

### DIFF
--- a/src/leiningen/spec.clj
+++ b/src/leiningen/spec.clj
@@ -1,6 +1,7 @@
 (ns leiningen.spec
   (:use
-    [clojure.java.io :only [file]])
+    [clojure.java.io :only [file]]
+    [leiningen.core.main :only [exit]])
   (:import
     [java.io BufferedInputStream]))
 
@@ -46,4 +47,4 @@
   (let [speclj-args (cons "-c" args)
         classpath (compute-classpath-string project)
         jvm-args ["-cp" classpath "-Dspeclj.invocation=lein spec"]]
-    (java jvm-args "speclj.main" speclj-args (:root project))))
+    (exit (java jvm-args "speclj.main" speclj-args (:root project)))))


### PR DESCRIPTION
Fixes the following warning:

WARNING: using numeric exit values in plugins is deprecated.
Plugins should use leiningen.core.main/abort instead.
Support for this will be removed before the stable 2.0.0 release.
spec failed.
