### PR TITLE
Notify reporter when compilation fails

### DIFF
--- a/spec/speclj/report/documentation_spec.clj
+++ b/spec/speclj/report/documentation_spec.clj
@@ -27,6 +27,10 @@
     (report-description @reporter @description)
     (should= (str endl "Verbosity" endl) (to-s @output)))
 
+  (it "doesnt report errors"
+    (report-error @reporter (Exception. "Compilation failed"))
+    (should= "" (to-s @output)))
+
   (it "reports pass"
     (let [characteristic (new-characteristic "says pass" @description "pass")
           result (pass-result characteristic 1)]

--- a/spec/speclj/report/progress_spec.clj
+++ b/spec/speclj/report/progress_spec.clj
@@ -52,6 +52,10 @@
     (report-description @reporter nil)
     (should= "" (to-s @output)))
 
+  (it "doesnt report errors"
+    (report-error @reporter (Exception. "Compilation failed"))
+    (should= "" (to-s @output)))
+
   (it "reports passing run results"
     (binding [*color?* true]
       (let [result1 (pass-result nil 0.1)

--- a/src/speclj/report/documentation.clj
+++ b/src/speclj/report/documentation.clj
@@ -36,7 +36,8 @@
           level (level-of characteristic)]
       (println (red (indent (dec level) "- " (.name characteristic) " (FAILED)"))) (flush)))
   (report-runs [this results]
-    (print-summary results)))
+    (print-summary results))
+  (report-error [this exception]))
 
 (defn new-documentation-reporter []
   (DocumentationReporter.))

--- a/src/speclj/report/progress.clj
+++ b/src/speclj/report/progress.clj
@@ -86,7 +86,8 @@
     (print (red "F")) (flush))
   (report-runs [this results]
     (println)
-    (print-summary results)))
+    (print-summary results))
+  (report-error [this exception]))
 
 (defn new-progress-reporter []
   (ProgressReporter.))

--- a/src/speclj/report/silent.clj
+++ b/src/speclj/report/silent.clj
@@ -11,7 +11,8 @@
   (report-pass [this result])
   (report-pending [this result])
   (report-fail [this result])
-  (report-runs [this results]))
+  (report-runs [this results])
+  (report-error [this exception]))
 
 (defn new-silent-reporter []
   (SilentReporter. (atom 0) (atom 0) (atom nil)))

--- a/src/speclj/reporting.clj
+++ b/src/speclj/reporting.clj
@@ -33,7 +33,8 @@
   (report-pass [this result])
   (report-pending [this result])
   (report-fail [this result])
-  (report-runs [this results]))
+  (report-runs [this results])
+  (report-error [this exception]))
 
 (defmulti report-run (fn [result reporters] (type result)))
 (defmethod report-run PassResult [result reporters]
@@ -128,3 +129,6 @@
   (doseq [reporter reporters]
     (report-message reporter message)))
 
+(defn report-error* [reporters exception]
+  (doseq [reporter reporters]
+    (report-error reporter exception)))

--- a/src/speclj/run/vigilant.clj
+++ b/src/speclj/run/vigilant.clj
@@ -3,7 +3,7 @@
     [speclj.running :only (do-description run-and-report run-description)]
     [speclj.util]
     [speclj.results :only (categorize)]
-    [speclj.reporting :only (report-runs* report-message* print-stack-trace)]
+    [speclj.reporting :only (report-runs* report-message* report-error* print-stack-trace)]
     [speclj.config :only (active-runner active-reporters config-bindings *specs*)]
     [fresh.core :only (freshener make-fresh ns-to-file clj-files-in)]
     [clojure.java.io :only (file)])
@@ -53,7 +53,9 @@
         (when (seq @(.results runner))
           (reset! (.previous-failed runner) (:fail (categorize (seq @(.results runner)))))
           (run-and-report runner reporters))
-        (catch Throwable e (print-stack-trace e *out*)))
+        (catch Throwable e
+          (report-error* reporters e)
+          (print-stack-trace e *out*)))
       (reset! (.results runner) []))))
 
 (deftype VigilantRunner [file-listing results previous-failed directories]


### PR DESCRIPTION
I'm currently working on updating speclj-growl to work with the latest version of clojure/speclj, I've got it working but I've got a downstream dependency i've submitted a patch for before I can publish.

One thing that I think would be useful for a plugin like this, is to be notified when a compilation error occurs - at the moment it just goes quiet when there's a problem and you're left to tab back to the terminal to find out what's going on.

I'll probably have a go at putting together a patch for this in the next week or so if no-one else gets to it first.
