### PR TITLE
adding --no-color with alias -C to spec task

### DIFF
--- a/spec/speclj/main_spec.clj
+++ b/spec/speclj/main_spec.clj
@@ -79,6 +79,10 @@
     (should= "on" (:color (parse-args "--color")))
     (should= "on" (:color (parse-args "-c"))))
 
+  (it "parses the --no-color switch"
+      (should= nil (:color (parse-args "-C")))
+      (should= nil (:color (parse-args "-c" "-C"))))
+
   (it "builds var mappings from config"
     (with-bindings (config/config-mappings {:runner "standard" :reporter "progress" :color true})
       (should= true config/*color?*)))

--- a/src/speclj/main.clj
+++ b/src/speclj/main.clj
@@ -15,6 +15,7 @@
   (.addSwitchOption "a" "autotest" "Alias to use the 'vigilant' runner and 'specdoc' reporter.")
   (.addSwitchOption "b" "stacktrace" "Output full stacktrace")
   (.addSwitchOption "c" "color" "Show colored (red/green) output.")
+  (.addSwitchOption "C" "no-color" "Disable colored output (helpful for writing to file).")
   (.addMultiOption "f" "reporter" "REPORTER" (str "Specifies how to report spec results. Ouput will be written to *out*. Multiple reporters are allowed.  Builtin reporters:" endl
                                                "  [d]ocumentation:  (description/context and characteristic names)" endl
                                                "  [p]rogress:       (default - dots)" endl
@@ -48,6 +49,7 @@
     (:reporter options) (recur (dissoc (assoc options :reporters (map resolve-reporter-alias (:reporter options))) :reporter))
     (= "s" (:runner options)) (recur (assoc options :runner "standard"))
     (= "v" (:runner options)) (recur (assoc options :runner "vigilant"))
+    (:no-color options) (recur (dissoc options :color :no-color))
     (:tag options) (recur (dissoc (assoc options :tags (:tag options)) :tag))
     :else options))
 


### PR DESCRIPTION
See issue https://github.com/slagyr/speclj/issues/63

Adds an override that allows a user to kick off spec tasks without color output. This can be for automation and parsing of errors.
