### PR TITLE
Nested stubs and more granular expectations on stubs

### DIFF
--- a/spec/speclj/stub_spec.clj
+++ b/spec/speclj/stub_spec.clj
@@ -111,7 +111,7 @@
       (it "with no parameters - failing"
         (@foo 1)
         (should-fail! (should-have-invoked :foo {:with []}))
-        (should= (str "Expected: invocation of :foo with []" endl "     got: [1]")
+        (should= (str "Expected: invocation of :foo with []" endl "     got: ([1])")
           (failure-message (should-have-invoked :foo {:with []}))))
 
       (it "with no parameters - passing"
@@ -122,7 +122,7 @@
       (it "with some parameters - failing"
         (@foo 3 2 1)
         (should-fail! (should-have-invoked :foo {:with [1 2 3]}))
-        (should= (str "Expected: invocation of :foo with [1 2 3]" endl "     got: [3 2 1]")
+        (should= (str "Expected: invocation of :foo with [1 2 3]" endl "     got: ([3 2 1])")
           (failure-message (should-have-invoked :foo {:with [1 2 3]}))))
 
       (it "with some parameters - passing"
@@ -137,7 +137,6 @@
         (should-pass! (should-have-invoked :foo {:with [:* :* 3]}))
         (should-fail! (should-have-invoked :foo {:with [0 :* :*]})))
 
-
       (it "with fn matchers"
         (@bar nil?)
         (should-pass! (should-have-invoked :bar {:with [nil?]}))
@@ -148,6 +147,97 @@
         (should-pass! (should-have-invoked :foo {:with [#(not (nil? %)) #(not (nil? %)) #(not (nil? %))]}))
         (should-fail! (should-have-invoked :foo {:with [#(< 5 %) :* :*]}))
         (should-fail! (should-have-invoked :foo {:with [:* #(nil? %) :*]})))
+
+      (it "calls the same stub two different times with different args"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (should-have-invoked :the-stub {:with [:one :two]})
+          (should-have-invoked :the-stub {:with [:three :four]})))
+
+      (it "calls the same stub many different times with different args"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (f :three :four)
+          (should-pass! (should-have-invoked :the-stub {:with [:one :two] :times 2}))
+          (should-pass! (should-have-invoked :the-stub {:with [:three :four] :times 3}))))
+
+      (it "fails when the number of times does not match for a given invocation"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (should-pass! (should-have-invoked :the-stub {:with [:three :four] :times 2}))
+          (should-fail! (should-have-invoked :the-stub {:with [:one :two] :times 2}))
+          (should= (str "Expected: 2 invocations of :the-stub with [:one :two]" endl "     got: 1 invocation")
+                   (failure-message (should-have-invoked :the-stub {:with [:one :two] :times 2})))
+          (should= (str "Expected: 1 invocation of :the-stub with [:three :four]" endl "     got: 2 invocations")
+                   (failure-message (should-have-invoked :the-stub {:with [:three :four] :times 1})))))
+      )
+
+    (context "should-not-have-invoked"
+
+      (it "fails when the number of times and args matches for a given invocation"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (should-fail! (should-not-have-invoked :the-stub {:with [:three :four] :times 2}))
+          (should= (str "Expected: :the-stub not to have been invoked 2 times with [:three :four]" endl "     got: 2 invocations")
+                   (failure-message (should-not-have-invoked :the-stub {:with [:three :four] :times 2})))
+          (should= (str "Expected: :the-stub not to have been invoked 1 time with [:one :two]" endl "     got: 1 invocation")
+                   (failure-message (should-not-have-invoked :the-stub {:with [:one :two] :times 1})))))
+
+      (it "passes when the number of times and args does not match for a given invocation"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (should-pass! (should-not-have-invoked :the-stub {:with [:one :two] :times 0}))
+          (should-pass! (should-not-have-invoked :the-stub {:with [:three :four] :times 1}))))
+
+      (it "passes when the number of times does not match for a given invocation"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (should-pass! (should-not-have-invoked :the-stub {:times 0}))
+          (should-pass! (should-not-have-invoked :the-stub {:times 1}))
+          (should-pass! (should-not-have-invoked :the-stub {:times 2}))
+          (should-pass! (should-not-have-invoked :the-stub {:times 4}))))
+
+      (it "fails when the number of times does not match for a given invocation with no args"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (should-pass! (should-not-have-invoked :the-stub {:times 4}))
+          (should= (str "Expected: :the-stub not to have been invoked 3 times" endl "     got: 3 invocations")
+                   (failure-message (should-not-have-invoked :the-stub {:times 3})))))
+
+      (it "passes when the args do not match for a given invocation"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (should-pass! (should-not-have-invoked :the-stub {:with [:one :three]}))
+          (should-pass! (should-not-have-invoked :the-stub {:with [:one :four]}))
+          (should-pass! (should-not-have-invoked :the-stub {:with [:two :four]}))))
+
+      (it "fails when the args match for a given invocation"
+        (let [f (stub :the-stub)]
+          (f :one :two)
+          (f :three :four)
+          (f :three :four)
+          (should-fail! (should-not-have-invoked :the-stub {:with [:one :two]}))
+          (should-fail! (should-not-have-invoked :the-stub {:with [:three :four]}))
+          (should= (str "Expected: :the-stub not to have been invoked with [:one :two]" endl "     got: ([:one :two] [:three :four] [:three :four])")
+                   (failure-message (should-not-have-invoked :the-stub {:with [:one :two]})))
+          (should= (str "Expected: :the-stub not to have been invoked with [:three :four]" endl "     got: ([:one :two] [:three :four] [:three :four])")
+                   (failure-message (should-not-have-invoked :the-stub {:with [:three :four]})))))
 
       )
 
@@ -183,6 +273,26 @@
 
       (it "stubs and checks simple call - passing"
         (should-pass! (should-not-invoke println {} "No calls to println :(")))
+
+      (it "uses should-not-have-invoked"
+        (should-pass! (should-not-invoke println {:times 3}
+                                         (println "hello!")
+                                         (println "hello again!"))))
+
+      (it "allows for nested should-invoke's"
+        (should-pass!
+          (should-invoke reverse {:times 1}
+            (should-invoke println {:times 1}
+              (println "hello!")
+              (reverse [1 2])))))
+
+      (it "allows for nested should-not-invoke's"
+        (should-pass!
+          (should-invoke reverse {:times 2}
+            (reverse [1 2])
+            (should-not-invoke println {:times 2}
+              (println "hello!")
+              (reverse [1 2])))))
 
       )
     )


### PR DESCRIPTION
This PR addresses the following use cases:

Granular expectations

``` clojure
(let [f (stub :the-stub)]
  (f :one :two)
  (f :three :four)
  (should-have-invoked :the-stub {:with [:one :two]})
  (should-have-invoked :the-stub {:with [:three :four]}))
```

Nested stubs

``` clojure
(it "allows for nested should-invoke's"
  (should-pass!
    (should-invoke reverse {:times 1}
      (should-invoke println {:times 1}
        (println "hello!")
        (reverse [1 2])))))
```

This offers a backwards compatible implementation that allows nesting multiple should-invokes. GH-74 tries to accomplish the same thing but unfortunately changes the API of should-invoke.
