### PR TITLE
Treat '--speclj' as an alternative help option

### DIFF
--- a/spec/clj/speclj/cli_spec.clj
+++ b/spec/clj/speclj/cli_spec.clj
@@ -59,6 +59,15 @@
     (should= 0 (run "--help"))
     (should-not= -1 (.indexOf (to-s @output) "Usage")))
 
+  (it "parses the --speclj switch"
+    (should= nil (:speclj (parse-args "")))
+    (should= "on" (:speclj (parse-args "--speclj")))
+    (should= "on" (:speclj (parse-args "-S"))))
+
+  (it "handles the --speclj switch"
+    (should= 0 (run "--speclj"))
+    (should-not= -1 (.indexOf (to-s @output) "Usage")))
+
   (it "parses and translates the --autotest option"
     (let [options (parse-args "--autotest")]
       (should= "vigilant" (:runner options))

--- a/src/clj/speclj/cli.clj
+++ b/src/clj/speclj/cli.clj
@@ -30,7 +30,7 @@
   (.addMultiOption "t" "tag" "TAG" "Run only the characteristics with the specified tag(s).\nTo exclude characteristics, prefix the tag with ~ (eg ~slow).  Use this option multiple times to filter multiple tags.")
   (.addSwitchOption "v" "version" "Shows the current speclj version.")
   (.addSwitchOption "h" "help" "You're looking at it.")
-  )
+  (.addSwitchOption "S" "speclj" "You're looking at it."))
 
 (defn- resolve-runner-alias [name]
   (cond
@@ -97,6 +97,6 @@
     (cond
       (:*errors config) (usage (:*errors config))
       (:version config) (do (print-version) 0)
-      (:help config) (usage nil)
+      (or (:speclj config) (:help config)) (usage nil)
       :else (or (do-specs config) 0))))
 


### PR DESCRIPTION
My attempt at tackling #102. 

I wanted to remove the "help" option altogether, but didn't want to risk deprecating existing functionality. Given that Leiningen hijacks the "help" flag, is there another way that it could be used? If not, then we can kill it.

It's also worth mentioning that according to [Leiningen's plugin docs](https://github.com/technomancy/leiningen/blob/master/doc/PLUGINS.md) you should be able to attach `^:pass-through-help` metadata to your defined task to implement this workaround; this didn't work for me for some reason.
