### PR TITLE
Fix example reporters config in run-specs docs

### DIFF
--- a/src/cljs/speclj/run/standard.cljs
+++ b/src/cljs/speclj/run/standard.cljs
@@ -49,7 +49,7 @@
 runner and reporter.  A call to this function is typically placed at the end of a spec file so that all the specs
 are evaluated by evaluation the file as a script.  Optional configuration paramters may be passed in:
 
-(run-specs :stacktrace true :color false :reporter \"documentation\")"
+(run-specs :stacktrace true :color false :reporters [\"documentation\"])"
   (when armed
     (let [config (apply hash-map configurations)
           config (merge (dissoc default-config :runner) config)]


### PR DESCRIPTION
The example shown was for when there was only a single reporter passed through as a string rather than now, where a vector is passed through with the key “reporters”.
