### PR TITLE
Enable consumption of 'omit-parsing' flag to disable

### DIFF
--- a/spec/clj/speclj/cli_spec.clj
+++ b/spec/clj/speclj/cli_spec.clj
@@ -97,6 +97,11 @@
       (should= nil (:color (parse-args "-C")))
       (should= nil (:color (parse-args "-c" "-C"))))
 
+  (it "parses the --omit-pending option"
+    (should= nil (:omit-pending (parse-args "")))
+    (should= "on" (:omit-pending (parse-args "-p")))
+    (should= "on" (:omit-pending (parse-args "--omit-pending"))))
+
   (it "builds var mappings from config"
     (with-bindings (config/config-mappings {:runner "standard" :reporter "progress" :color true})
       (should= true config/*color?*)))
@@ -127,7 +132,6 @@
     (should= ["one"] (:tags (parse-args "-t" "one")))
     (should= ["one" "~two"] (:tags (parse-args "--tag=one" "--tag=~two")))
     (should= ["one" "~two"] (:tags (parse-args "-t" "one" "-t" "~two"))))
-
-  )
+)
 
 (run-specs)

--- a/spec/clj/speclj/cli_spec.clj
+++ b/spec/clj/speclj/cli_spec.clj
@@ -98,7 +98,7 @@
       (should= nil (:color (parse-args "-c" "-C"))))
 
   (it "parses the --omit-pending option"
-    (should= nil (:omit-pending (parse-args "")))
+    (should= false (:omit-pending (parse-args "")))
     (should= "on" (:omit-pending (parse-args "-p")))
     (should= "on" (:omit-pending (parse-args "--omit-pending"))))
 

--- a/spec/cljx/speclj/report/progress_spec.cljx
+++ b/spec/cljx/speclj/report/progress_spec.cljx
@@ -16,7 +16,7 @@
 (describe "Progress Reporter"
   (with reporter (new-progress-reporter))
   (around [spec] (binding [*color?* false
-                           *omit-pending?* nil]
+                           *omit-pending?* false]
                    (spec)))
 
   (it "reports pass"

--- a/spec/cljx/speclj/report/progress_spec.cljx
+++ b/spec/cljx/speclj/report/progress_spec.cljx
@@ -5,7 +5,7 @@
             ;cljs-include [goog.string] ;cljs bug?
             #+cljs [goog.string]
             [speclj.components :refer [new-description new-characteristic install]]
-            [speclj.config :refer [*color?* *full-stack-trace?*]]
+            [speclj.config :refer [*color?* *full-stack-trace?* *omit-pending?*]]
             [speclj.platform :refer [format-seconds]]
             [speclj.report.progress :refer [new-progress-reporter full-name print-summary print-pendings print-errors]]
             [speclj.reporting :refer [report-description report-pass report-pending
@@ -15,7 +15,9 @@
 
 (describe "Progress Reporter"
   (with reporter (new-progress-reporter))
-  (around [spec] (binding [*color?* false] (spec)))
+  (around [spec] (binding [*color?* false
+                           *omit-pending?* nil]
+                   (spec)))
 
   (it "reports pass"
     (should= "."
@@ -120,6 +122,14 @@
       (should= (grey "    ; Not Yet Implemented") (nth lines 4))
       ;      (should= (grey "    ; /Users/micahmartin/Projects/clojure/speclj/spec/speclj/report/progress_spec.clj:117") (nth lines 5))
       ))
+
+   (it "doesn't report pending summary with omit-pending flag enabled"
+    (binding [*omit-pending?* "on"]
+      (let [description (new-description "Crazy" "some.ns")
+            char1 (new-characteristic "flips" description "flip")
+            result1 (pending-result char1 0.3 (-new-pending "Not Yet Implemented"))
+            printed-results (with-out-str (print-pendings [result1]))]
+        (should= "" printed-results))))
 
   (it "reports error run results"
     (binding [*color?* true]

--- a/src/clj/speclj/cli.clj
+++ b/src/clj/speclj/cli.clj
@@ -18,6 +18,7 @@
   (.addSwitchOption "b" "stacktrace" "Output full stacktrace")
   (.addSwitchOption "c" "color" "Show colored (red/green) output.")
   (.addSwitchOption "C" "no-color" "Disable colored output (helpful for writing to file).")
+  (.addSwitchOption "p" "omit-pending" "Disable messages about pending specs. The number of pending specs and progress meter will still be shown.")
   (.addMultiOption "D" "default-spec-dirs" "DEFAULT_SPEC_DIRS" "[INTERNAL USE] Default spec directories (overridden by specs given separately).")
   (.addMultiOption "f" "reporter" "REPORTER" (str "Specifies how to report spec results. Ouput will be written to *out*. Multiple reporters are allowed.  Builtin reporters:" endl
                                                "  [c]lojure-test:   (reporting via clojure.test/report)" endl

--- a/src/cljx/speclj/config.cljx
+++ b/src/cljx/speclj/config.cljx
@@ -35,6 +35,8 @@
 
 (def #^{:dynamic true} *color?* false)
 
+(def #^{:dynamic true} *omit-pending?* false)
+
 (def #^{:dynamic true} *full-stack-trace?* false)
 
 (def #^{:dynamic true} *tag-filter* {:include #{} :exclude #{}})
@@ -102,6 +104,7 @@
    #'*reporters*         (if (:reporters config) (map load-reporter (:reporters config)) (active-reporters))
    #'*specs*             (:specs config)
    #'*color?*            (:color config)
+   #'*omit-pending?*     (:omit-pending config)
    #'*full-stack-trace?* (not (nil? (:stacktrace config)))
    #'*tag-filter*        (parse-tags (:tags config))})
 

--- a/src/cljx/speclj/config.cljx
+++ b/src/cljx/speclj/config.cljx
@@ -33,9 +33,9 @@
 
 (declare #^{:dynamic true} *specs*)
 
-(def #^{:dynamic true} *color?* false)
-
 (def #^{:dynamic true} *omit-pending?* false)
+
+(def #^{:dynamic true} *color?* false)
 
 (def #^{:dynamic true} *full-stack-trace?* false)
 
@@ -45,7 +45,8 @@
   {:specs     ["spec"]
    :runner    "standard"
    :reporters ["progress"]
-   :tags      []})
+   :tags      []
+   :omit-pending false})
 
 #+clj
 (defn config-bindings
@@ -119,6 +120,7 @@
             *reporters* (if (:reporters config) (mapv load-reporter (:reporters config)) (active-reporters))
             *specs* (:specs config)
             *color?* (:color config)
+            *omit-pending?* (:omit-pending config)
             *full-stack-trace?* (not (nil? (:stacktrace config)))
             *tag-filter* (parse-tags (:tags config))]
     (action)))

--- a/src/cljx/speclj/report/progress.cljx
+++ b/src/cljx/speclj/report/progress.cljx
@@ -1,5 +1,5 @@
 (ns speclj.report.progress
-  (:require [speclj.config :refer [default-reporters]]
+  (:require [speclj.config :refer [default-reporters *omit-pending?*]]
             [speclj.platform :as platform]
             [speclj.reporting :refer [tally-time red green yellow grey stack-trace-str indent prefix]]
             [speclj.results :refer [pass? fail? pending? categorize]]
@@ -29,14 +29,15 @@
     (print-failure (inc i) (nth failures i))))
 
 (defn print-pendings [pending-results]
-  (when (seq pending-results)
-    (println)
-    (println "Pending:"))
-  (doseq [result pending-results]
-    (println)
-    (println (yellow (str "  " (full-name (.-characteristic result)))))
-    (println (grey (str "    ; " (platform/error-message (.-exception result)))))
-    (println (grey (str "    ; " (platform/failure-source (.-exception result)))))))
+  (when-not *omit-pending?*
+    (when (seq pending-results)
+      (println)
+      (println "Pending:"))
+    (doseq [result pending-results]
+      (println)
+      (println (yellow (str "  " (full-name (.-characteristic result)))))
+      (println (grey (str "    ; " (platform/error-message (.-exception result)))))
+      (println (grey (str "    ; " (platform/failure-source (.-exception result))))))))
 
 (defn print-errors [error-results]
   (when (seq error-results)


### PR DESCRIPTION
This is a first pass #121.

Notably, it only handles the command-line invocation case. I was en route to tackling the other use-case but I can't understand the [identity check](https://github.com/slagyr/speclj/blob/master/src/clj/speclj/run/standard.clj#L51) in `standard.clj`. I tried running a single file to inspect the `active-runner` and `default-runner`. They were the same class but not the same instance. Given that, I'm not actually sure under what circumstances that check would return true. Any insight here would be much appreciated.

Uses:
`lein spec -p`
`lein spec --omit-pending`