### PR TITLE
Minor change to the contributing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ $ lein spec
 To make sure tests pass ClojureScript too, make sure you have [phantomjs](http://phantomjs.org/download.html) installed and then run:
 
 ```bash
-lein cljsbuild clean
-lein cljsbuild once
+lein clean
+lein cljs
 ```
 
 Make patches and submit them along with an issue (see below).


### PR DESCRIPTION
The targets for doing the clojurescript tests on speclj itself (in the contributing section) seem to be out of date.