### PR TITLE
Spec runner should return errors

### DIFF
--- a/bin/specs.html
+++ b/bin/specs.html
@@ -26,7 +26,7 @@
         };
 
         runSpecs = function () {
-            runSpecsConfigured(false, "documentation");
+            return runSpecsConfigured(false, "documentation");
         }
 
         runSpecsPhantom = function (affectedSpecs) {
@@ -42,7 +42,7 @@
                     console.log("  ", description.ns);
                 }, cljs.core.deref(descriptionAtom)));
             }
-            runSpecsConfigured(true, "documentation");
+            return runSpecsConfigured(true, "documentation");
         }
     </script>
 </head>


### PR DESCRIPTION
When running `phantomjs bin/speclj.js` in a terminal with failing spec, I should get back a non-zero error, and I should get a success when all specs are passing.

This PR fixes that.
