### PR TITLE
Support .cljc specs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject speclj "3.3.1"
+(defproject speclj "3.3.2-SNAPSHOT"
             :description "speclj: Pronounced 'speckle', is a Behavior Driven Development framework for Clojure."
             :url "http://speclj.com"
             :license {:name         "The MIT License"

--- a/src/speclj/core.clj
+++ b/src/speclj/core.clj
@@ -18,10 +18,10 @@
   ([message] (if cljs? `(js/Object. ~message) `(java.lang.Throwable. ~message))))
 
 (defmacro ^:no-doc -new-failure [message]
-  (if cljs? `(speclj.platform.SpecFailure. ~message) `(speclj.SpecFailure. ~message)))
+  `(speclj.platform.SpecFailure. ~message))
 
 (defmacro ^:no-doc -new-pending [message]
-  (if cljs? `(speclj.platform.SpecPending. ~message) `(speclj.SpecPending. ~message)))
+  `(speclj.platform.SpecPending. ~message))
 
 (defmacro it
   "body => any forms but aught to contain at least one assertion (should)

--- a/src/speclj/platform.clj
+++ b/src/speclj/platform.clj
@@ -9,8 +9,8 @@
 
 (def throwable Throwable)
 (def exception java.lang.Exception)
-(def failure speclj.SpecFailure)
-(def pending speclj.SpecPending)
+(def failure speclj.platform.SpecFailure)
+(def pending speclj.platform.SpecPending)
 
 (defn pending? [e] (isa? (type e) pending))
 (defn failure? [e] (isa? (type e) failure))

--- a/src/speclj/platform/SpecFailure.java
+++ b/src/speclj/platform/SpecFailure.java
@@ -1,4 +1,4 @@
-package speclj;
+package speclj.platform;
 
 public class SpecFailure extends Exception
 {

--- a/src/speclj/platform/SpecPending.java
+++ b/src/speclj/platform/SpecPending.java
@@ -1,4 +1,4 @@
-package speclj;
+package speclj.platform;
 
 public class SpecPending extends Exception
 {


### PR DESCRIPTION
This addresses #133, by eliminating the discrepancy between Clojure and ClojureScript classes for `SpecFailure` and `SpecPending`. It made sense to me that both should be in `speclj.platform`, since they are essentially platform-specific implementations of the same APIs.

I verified this against the [test repo](https://github.com/milt/spectest) and instructions provided by milt in #133, as well as in my own project where I encountered the issue.

I was unable to reproduce the issue in specs within the speclj project (in fact, it appears there are already `.cljc` tests running successfully), but I suspect this has something to do with a difference between how speclj's own specs are compiled and initialized, versus a typical `lein-cljsbuild` project with the test runner described in README.