### PR TITLE
JUnit reporter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject speclj "3.3.1"
+(defproject speclj "3.3.2-SNAPSHOT"
             :description "speclj: Pronounced 'speckle', is a Behavior Driven Development framework for Clojure."
             :url "http://speclj.com"
             :license {:name         "The MIT License"
@@ -14,6 +14,9 @@
             :java-source-paths ["src"]
 
             :dependencies [[org.clojure/clojure "1.7.0-RC2"]
+                           [org.clojure/data.xml "0.0.8"]
+                           [clj-time "0.11.0"]
+                           [com.andrewmcveigh/cljs-time "0.3.14"]
                            [fresh "1.1.2"]
                            [mmargs "1.2.0"]
                            [trptcolin/versioneer "0.1.1"]]

--- a/spec/speclj/report/junit/xml_spec.cljs
+++ b/spec/speclj/report/junit/xml_spec.cljs
@@ -1,0 +1,31 @@
+(ns speclj.report.junit.xml-spec
+  (:require-macros [speclj.core :refer [describe it should= should-not-throw]])
+  (:require [speclj.core]
+            [speclj.report.junit.xml :as xml]))
+
+(describe "ClojureScript XML"
+  (it "generates XML with semantics similar to clojure.data.xml"
+    (let [testcase (xml/element :testcase
+                    {:classname "A test works?"
+                     :name "A test works?"
+                     :time "0.0001"})
+          testsuite (xml/element :testsuite
+                     {:name "speclj"
+                      :errors 0
+                      :skipped 0
+                      :tests 1
+                      :failures 0
+                      :time "0.0001"
+                      :timestamp (js/Date. "2015-12-14T21:04:48.631Z")}
+                     testcase)
+          testsuites (xml/element :testsuites {} testsuite)]
+      (should= (xml/emit-str testsuites)
+               (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    "<testsuites>"
+                      "<testsuite name=\"speclj\" errors=\"0\" skipped=\"0\" "
+                        "tests=\"1\" failures=\"0\" time=\"0.0001\" "
+                        "timestamp=\"2015-12-14T21:04:48.631Z\">"
+                        "<testcase classname=\"A test works?\" "
+                          "name=\"A test works?\" time=\"0.0001\"></testcase>"
+                      "</testsuite>"
+                    "</testsuites>")))))

--- a/spec/speclj/report/junit_spec.cljc
+++ b/spec/speclj/report/junit_spec.cljc
@@ -1,0 +1,123 @@
+(ns speclj.report.junit-spec
+  (#?(:clj :require :cljs :require-macros)
+    [speclj.core :refer [around before context describe it should should=
+                         with -new-exception -new-failure -new-pending]])
+  (:require [clojure.string :refer [join split-lines]]
+    #?(:clj  [clj-time.core :as t]
+       :cljs [cljs-time.core :as t])
+    #?(:cljs [goog.string])                                 ;cljs bug?
+            [speclj.components :refer [new-description new-characteristic install]]
+            [speclj.config :refer [*color?*]]
+            [speclj.platform :refer [endl format-seconds]]
+            [speclj.report.junit :refer [now new-junit-reporter]]
+            [speclj.reporting :refer [report-runs]]
+            [speclj.results :refer [pass-result fail-result pending-result error-result]]
+            [speclj.run.standard :refer [run-specs]]))
+
+(def date-time (t/date-time 1970 1 1))
+(def date #?(:clj  date-time
+             :cljs (.-date date-time)))
+(def date-str "1970-01-01T00:00:00.000Z")
+
+(def default-counts
+  {:errors 0 :skipped 0 :tests 1 :failures 0})
+
+(defn xml [counts & strs]
+  (let [{:keys [errors skipped tests failures]} (merge default-counts counts)]
+    (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+          "<testsuites>"
+            "<testsuite name=\"speclj\" "
+              "errors=\"" errors "\" skipped=\"" skipped "\" "
+              "tests=\"" tests "\" failures=\"" failures "\" "
+              "time=\"0\" timestamp=\"" date-str "\">"
+              (apply str strs)
+            "</testsuite>"
+          "</testsuites>"
+          endl)))
+
+(defn testcase [class-name & strs]
+  (str "<testcase classname=\"" class-name "\" name=\"" class-name "\" time=\"0\">"
+       (apply str strs)
+       "</testcase>"))
+
+(defn exception [message]
+  #?(:clj (Exception. message)
+     :cljs (Error. message)))
+
+(defn class-name [x]
+  #?(:clj  (.. x getClass getCanonicalName)
+     :cljs (.-name (type x))))
+
+(defn stack-trace-str [e]
+  #?(:clj  (join "\n" (.getStackTrace e))
+     :cljs (str (.-stack e))))
+
+(describe "JUnit Reporter"
+  (with reporter (new-junit-reporter))
+  (with description (new-description "JUnit" "some-ns"))
+
+  (around [it]
+    (with-redefs [format-seconds (fn [arg] "0")
+                  t/now (fn [] date)]
+      (it)))
+
+  (it "reports errors"
+    (let [e (ex-info "welp" {})
+          result (error-result e)
+          reporter @reporter]
+      (should= (xml {:errors 1 :tests 0}
+                    (testcase (class-name e)
+                              "<error message=\"welp\">"
+                              (stack-trace-str e)
+                              "</error>"))
+               (with-out-str (report-runs reporter [result])))))
+
+  (it "reports pass"
+    (let [characteristic (new-characteristic "says pass" @description "pass")
+          result (pass-result characteristic 1)]
+      (should= (xml default-counts
+                    (testcase "JUnit says pass"))
+               (with-out-str (report-runs @reporter [result])))))
+
+  (it "reports pending"
+    (let [characteristic (new-characteristic "pending!" `(pending))
+          result (pending-result characteristic 1 (-new-pending "some reason for pendiness"))]
+      (should= (xml {:skipped 1}
+                    (testcase "pending!"
+                              "<skipped>"
+                                "some reason for pendiness"
+                              "</skipped>"))
+               (with-out-str (report-runs @reporter [result])))))
+
+  (it "reports fail"
+    (let [characteristic (new-characteristic "says fail" @description "fail")
+          result (fail-result characteristic 2 (-new-failure "blah"))]
+      (should= (xml {:failures 1}
+                    (testcase "JUnit says fail"
+                              "<failure message=\"test failure\">"
+                                "blah"
+                              "</failure>"))
+               (with-out-str (report-runs @reporter [result])))))
+
+  (context "with nested description"
+    (with nested-description (new-description "Nesting" "some.ns"))
+    (before (install @nested-description @description))
+
+    (it "reports nested pass"
+      (let [characteristic (new-characteristic "nested pass" @nested-description "pass")
+            result (pass-result characteristic 1)]
+        (should= (xml default-counts
+                    (testcase "JUnit Nesting nested pass"))
+                 (with-out-str (report-runs @reporter [result])))))
+
+    (it "reports nested failure"
+      (let [characteristic (new-characteristic "nested fail" @nested-description "fail")
+            result (fail-result characteristic 2 (-new-failure "blah"))]
+        (should= (xml {:failures 1}
+                    (testcase "JUnit Nesting nested fail"
+                              "<failure message=\"test failure\">"
+                                "blah"
+                              "</failure>"))
+                 (with-out-str (report-runs @reporter [result])))))))
+
+(run-specs)

--- a/src/speclj/report/junit.cljc
+++ b/src/speclj/report/junit.cljc
@@ -1,0 +1,130 @@
+(ns speclj.report.junit
+  (:require [clojure.string :as string]
+            [speclj.reporting]
+            [speclj.platform :refer [format-seconds]]
+            [speclj.report.progress :refer [full-name]]
+            [speclj.reporting :refer [tally-time]]
+            [speclj.results]
+            [clojure.string :refer [trim-newline]]
+#?(:clj     [clojure.data.xml :as xml]
+   :cljs    [speclj.report.junit.xml :as xml])
+#?(:clj     [clj-time.core :as t]
+   :cljs    [cljs-time.core :as t])
+#?(:cljs    [speclj.results :refer [PassResult FailResult PendingResult ErrorResult]]))
+  #?(:clj (:import [speclj.results PassResult FailResult PendingResult ErrorResult])))
+
+(def pass-count (atom 0))
+(def error-count (atom 0))
+(def fail-count (atom 0))
+(def skipped-count (atom 0))
+
+(defn- clear-atom [a]
+  (swap! a (fn [_] 0)))
+
+(defn- reset-counters []
+  (clear-atom pass-count)
+  (clear-atom error-count)
+  (clear-atom fail-count)
+  (clear-atom skipped-count))
+
+(defn- test-count [] (+ @pass-count @fail-count @skipped-count))
+
+(defn now []
+  (t/now))
+
+(defn failure-message [failure]
+  (try
+    (.getMessage failure)
+    (catch #?(:clj Exception :cljs :default) e
+      (.-message failure))))
+
+(defn- pass->xml [result]
+  (swap! pass-count inc)
+  (let [characteristic (.-characteristic result)
+        spec-name (full-name characteristic)
+        seconds (format-seconds (.-seconds result))]
+    (xml/element :testcase {:classname spec-name :name spec-name :time seconds})))
+
+(defn- pending->xml [result]
+  (swap! skipped-count inc)
+  (let [characteristic (.-characteristic result)
+        spec-name (full-name characteristic)
+        seconds (format-seconds (.-seconds result))
+        exception (.-exception result)]
+    (xml/element :testcase {:classname spec-name :name spec-name :time seconds}
+                 (xml/element :skipped {} (failure-message exception)))))
+
+(defn- fail->xml [result]
+  (swap! fail-count inc)
+  (let [characteristic (.-characteristic result)
+        spec-name (full-name characteristic)
+        seconds (format-seconds (.-seconds result))
+        failure (.-failure result)]
+    (xml/element :testcase {:classname spec-name :name spec-name :time seconds}
+                 (xml/element :failure {:message "test failure"} (failure-message failure)))))
+
+(defn class-name [x]
+  #?(:clj  (.. x getClass getCanonicalName)
+     :cljs (.-name (type x))))
+
+(defn stack-trace-str [e]
+  #?(:clj  (string/join "\n" (.getStackTrace e))
+     :cljs (str (.-stack e))))
+
+(defn message [e]
+  #?(:clj  (.getMessage e)
+     :cljs (.-message e)))
+
+(defn- error-result->xml [result]
+   (swap! error-count inc)
+   (let [exception (.-exception result)
+         class-name (class-name exception)
+         message (failure-message exception)
+         stacktrace (stack-trace-str exception)
+         seconds (format-seconds (.-seconds result))]
+        (xml/element :testcase {:classname class-name :name class-name :time seconds}
+          (xml/element :error {:message message} stacktrace))))
+
+(defn- result->xml [result]
+  (cond
+   (= PassResult (type result))
+   (pass->xml result)
+
+   (= PendingResult (type result))
+   (pending->xml result)
+
+   (= FailResult (type result))
+   (fail->xml result)
+
+   (= ErrorResult (type result))
+   (error-result->xml result)
+
+   :else
+   (println (str "Unknown result type: " (type result)))))
+
+(defn- runs->xml [results]
+  (reset-counters)
+  (let [xml-results (doall (map result->xml results))]
+    (xml/element :testsuites {}
+                 (xml/element :testsuite {:name "speclj"
+                                          :errors @error-count
+                                          :skipped @skipped-count
+                                          :tests (test-count)
+                                          :failures @fail-count
+                                          :time (format-seconds (tally-time results))
+                                          :timestamp (now)}
+                              xml-results))))
+
+(deftype JUnitReporter [passes fails results]
+  speclj.reporting/Reporter
+  (report-message [this message])
+  (report-description [this description])
+  (report-pass [this result])
+  (report-pending [this result])
+  (report-fail [this result])
+  (report-runs [this results]
+    (println (xml/emit-str (runs->xml results))))
+  (report-error [this exception]))
+
+(defn new-junit-reporter []
+  (JUnitReporter. (atom 0) (atom 0) (atom nil)))

--- a/src/speclj/report/junit/xml.cljs
+++ b/src/speclj/report/junit/xml.cljs
@@ -1,0 +1,68 @@
+;; Partial compatibility with API for clojure.data.xml, which depends
+;; on Java.xml.* - Uses browser/phantomjs DOM to construct XML
+(ns speclj.report.junit.xml
+  (:require [clojure.string :as string]))
+
+(declare content->child)
+
+(defn- content->children
+  "Create a DocumentFragment containing DOM representations of each child."
+  [content]
+  (let [fragment (js/document.createDocumentFragment)]
+    (doseq [x content]
+      (when-not (nil? x)
+        (.appendChild fragment (content->child x))))
+    fragment))
+
+(defn- ->str [x]
+  (cond
+    (instance? js/Date x) (.toISOString x)
+    (satisfies? INamed x) (name x)
+    :else (str x)))
+
+(defn- text
+  "Create a Text node suitable for appending to a DocumentFragment."
+  [x]
+  (js/document.createTextNode (->str x)))
+
+(def ^:private dom-node?
+  (partial instance? js/Node))
+
+(defn- content->child
+  "Returns a child DOM node:
+  - Self, if already a DOM node
+  - DocumentFragment if sequential
+  - Otherwise a Text node containing the string representation of x"
+  [x]
+  (cond
+    (dom-node? x)  x
+    (sequential? x)    (content->children x)
+    :else              (text x)))
+
+(defn- ->attr-val [attr-name x]
+  (if (instance? js/Boolean x)
+      (when x attr-name)
+      (->str x)))
+
+(defn element
+  "Create a DOM element. Used in place of clojure.data.xml/element"
+  [tag & [attrs & content]]
+  (let [el (js/document.createElement (name tag))
+        content- (remove nil? content)]
+    ;; Set attributes
+    (doseq [[k v] attrs
+            :let [attr-name (->str k)]]
+      (when-let [attr-val (->attr-val k v)]
+        (.setAttribute el attr-name attr-val)))
+
+    ;; Set content
+    (.appendChild el (content->child content))
+
+    el))
+
+(defn emit-str
+  "Emit XML string for an element. Used in place of clojure.data.xml/emit-str"
+  [el]
+  (string/trim
+    (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+         (.-outerHTML el))))


### PR DESCRIPTION
Addresses #104. Provides a JUnit XML reporter.

Adapts work from the following, which deserve most of the credit:

- https://github.com/julias-shaw/speclj-junit (mentioned in #104)
- https://github.com/julias-shaw/speclj-junit/pull/3 (PR into the former, providing error output)

(But I feel this deserves to be in the main lib.)

Changes to those prior works include:

- Support for ClojureScript
    - Besides typical clj -> cljc porting, I also included a namespace for DOM-based XML generation, providing (only) the relevant portions of the `clojure.data.xml` library (I was surprised that such a thing didn't already exist for cljs/cljc)
- Produces output to `*out*` (as other reporters do)
- Includes output for pending specs
- Simplifies error output implementation from https://github.com/julias-shaw/speclj-junit/pull/3, which included some redundancy (hopefully; at least the specs pass, and a cursory attempt to exercise those code paths seems to validate it in real life)