### PR TITLE
New core api macro: focus-it

### DIFF
--- a/examples/focused/focused.clj
+++ b/examples/focused/focused.clj
@@ -1,0 +1,41 @@
+(ns focused
+  (:require [speclj.core :refer :all]))
+
+(describe "ONLY THE FOCUSED COMPONENTS WILL BE EXECUTED"
+
+  (it "downright fails"
+    (should-fail "fails for sure"))
+
+  (it "downright fail again"
+    (should-fail))
+
+  (it "fails on a boolean"
+    (should false))
+
+  (it "fails on equality"
+    (should= 1 2))
+
+  (focus-it "fails on inequality"                           ; THIS WILL BE EXECUTED
+    (should-not= 1 1))
+
+  (context "nested scope"
+    (focus-it "fails" (should= 1 2))                        ; THIS WILL BE EXECUTED
+    (it "isn't run" (should= 1 2)))
+
+  (it "fails to throw"
+    (should-throw (+ 1 1)))
+
+  (it "fails to throw the right error"
+    (should-throw Exception (throw (Error. "oops"))))
+
+  (it "fails to throw error with the right message"
+    (should-throw Exception "Howdy" (throw (Exception. "Hiya")))))
+
+(describe "Other Spec"
+  (focus-it "to run" (should= 1 2)))                        ; THIS WILL BE EXECUTED
+
+
+; TODO: focus-context
+; TODO: focus-describe
+
+(run-specs)

--- a/spec/speclj/report/documentation_spec.cljc
+++ b/spec/speclj/report/documentation_spec.cljc
@@ -1,8 +1,8 @@
 (ns speclj.report.documentation-spec
   (#?(:clj :require :cljs :require-macros)
-    [speclj.core :refer [around before context describe it should= with -new-exception -new-failure -new-pending]])
+   [speclj.core :refer [around before context describe it should= with -new-exception -new-failure -new-pending]])
   (:require [clojure.string :refer [split-lines]]
-    #?(:cljs [goog.string])                                 ;cljs bug?
+            #?(:cljs [goog.string])                         ;cljs bug?
             [speclj.components :refer [new-description new-characteristic install]]
             [speclj.config :refer [*color?*]]
             [speclj.platform :refer [endl]]
@@ -27,20 +27,32 @@
 
   (it "reports pass"
     (let [characteristic (new-characteristic "says pass" @description "pass")
-          result (pass-result characteristic 1)]
+          result         (pass-result characteristic 1)]
       (should= (str (green "- says pass") endl)
+               (with-out-str (report-pass @reporter result)))))
+
+  (it "reports focused pass"
+    (let [characteristic (new-characteristic "says pass" @description (with-meta #() {:focused? true}))
+          result         (pass-result characteristic 1)]
+      (should= (str (green "- says pass") " " (yellow "[FOCUS]") endl)
                (with-out-str (report-pass @reporter result)))))
 
   (it "reports pending"
     (let [characteristic (new-characteristic "pending!" `(pending))
-          result (pending-result characteristic 1 (-new-pending "some reason for pendiness"))]
+          result         (pending-result characteristic 1 (-new-pending "some reason for pendiness"))]
       (should= (str (yellow "- pending! (PENDING: some reason for pendiness)") endl)
                (with-out-str (report-pending @reporter result)))))
 
   (it "reports fail"
     (let [characteristic (new-characteristic "says fail" @description "fail")
-          result (fail-result characteristic 2 (-new-failure "blah"))]
+          result         (fail-result characteristic 2 (-new-failure "blah"))]
       (should= (str (red "- says fail (FAILED)") endl)
+               (with-out-str (report-fail @reporter result)))))
+
+  (it "reports focused fail"
+    (let [characteristic (new-characteristic "says fail" @description (with-meta #() {:focused? true}))
+          result         (fail-result characteristic 2 (-new-failure "blah"))]
+      (should= (str (red "- says fail (FAILED)") " " (yellow "[FOCUS]") endl)
                (with-out-str (report-fail @reporter result)))))
 
   (context "with nested description"
@@ -53,13 +65,13 @@
 
     (it "reports nested pass"
       (let [characteristic (new-characteristic "nested pass" @nested-description "pass")
-            result (pass-result characteristic 1)]
+            result         (pass-result characteristic 1)]
         (should= (str (green "  - nested pass") endl)
                  (with-out-str (report-pass @reporter result)))))
 
     (it "reports nested failure"
       (let [characteristic (new-characteristic "nested fail" @nested-description "fail")
-            result (fail-result characteristic 2 (-new-failure "blah"))]
+            result         (fail-result characteristic 2 (-new-failure "blah"))]
         (should= (str (red "  - nested fail (FAILED)") endl)
                  (with-out-str (report-fail @reporter result)))))
     )

--- a/spec/speclj/run/standard_spec.clj
+++ b/spec/speclj/run/standard_spec.clj
@@ -1,22 +1,22 @@
 (ns speclj.run.standard-spec
-  (:require [speclj.config :refer [active-reporters *runner*]]
-            [speclj.core :refer [describe with it should=]]
+  (:require [speclj.core :refer [describe it should= with]]
             [speclj.report.silent :refer [new-silent-reporter]]
             [speclj.run.standard :refer :all]
-            [speclj.running :refer [run-directories run-and-report]])
-  (:import [java.io File]))
+            [speclj.running :refer [run-directories]])
+  (:import (java.io File)))
 
 (defn find-dir
   ([name] (find-dir (File. (.getCanonicalPath (File. ""))) name))
   ([file name]
-    (let [examples (File. file name)]
-      (if (.exists examples)
-        examples
-        (find-dir (.getParentFile file) name)))))
+   (let [examples (File. file name)]
+     (if (.exists examples)
+       examples
+       (find-dir (.getParentFile file) name)))))
 
 (def examples-dir (find-dir "examples"))
 (def prime-factors-dir (.getCanonicalPath (File. examples-dir "prime_factors")))
 (def failures-dir (.getCanonicalPath (File. examples-dir "failures")))
+(def focused-dir (.getCanonicalPath (File. examples-dir "focused")))
 
 (describe "StandardRunner"
   (with runner (new-standard-runner))
@@ -27,6 +27,9 @@
 
   (it "returns lots-o failures when running failure example"
     (should= 8 (run-directories @runner [failures-dir] @reporters)))
+
+  (it "limits execution to focused components"
+    (should= 3 (run-directories @runner [focused-dir] @reporters)))
 
   )
 

--- a/src/speclj/components.cljc
+++ b/src/speclj/components.cljc
@@ -29,7 +29,7 @@
      object
      (install [this description] (comment "Whatever...  Let them pass."))))
 
-(deftype Description [name ns parent children charcteristics tags befores before-alls afters after-alls withs with-alls arounds around-alls]
+(deftype Description [name ns parent children characteristics tags befores before-alls afters after-alls withs with-alls arounds around-alls]
   SpecComponent
   (install [this description]
     (reset! (.-parent this) description)
@@ -44,7 +44,7 @@
   SpecComponent
   (install [this description]
     (reset! (.-parent this) description)
-    (swap! (.-charcteristics description) conj this))
+    (swap! (.-characteristics description) conj this))
   Object
   (toString [this] (str \" name \")))
 

--- a/src/speclj/components.cljc
+++ b/src/speclj/components.cljc
@@ -8,7 +8,7 @@
      java.lang.Object
      (install [this description] (comment "This prohibits multimethod defs, and other stuff.  Don't be so stingy! Let it pass."))
      nil
-     (install [this description] (throw (java.lang.Exception. (str "Oops!  It looks like you tried to add 'nil' to a spec.  That's probabaly not what you wanted."))))
+     (install [this description] (throw (java.lang.Exception. (str "Oops!  It looks like you tried to add 'nil' to a spec.  That's probably not what you wanted."))))
      clojure.lang.Var
      (install [this description] (comment "Vars are cool.  Let them pass."))
      clojure.lang.Seqable
@@ -25,7 +25,7 @@
      PersistentVector
      (install [this description] (doseq [component (seq this)] (install component description)))
      nil
-     (install [this description] (throw (ex-info (str "Oops!  It looks like you tried to add 'nil' to a spec.  That's probabaly not what you wanted.") {})))
+     (install [this description] (throw (ex-info (str "Oops!  It looks like you tried to add 'nil' to a spec.  That's probably not what you wanted.") {})))
      object
      (install [this description] (comment "Whatever...  Let them pass."))))
 

--- a/src/speclj/config.cljc
+++ b/src/speclj/config.cljc
@@ -44,7 +44,7 @@
 
 #?(:clj
    (defn config-bindings
-     "Retuns a map of vars to values for all the ear-muffed vars in the speclj.config namespace.
+     "Returns a map of vars to values for all the ear-muffed vars in the speclj.config namespace.
      Can be used in (with-bindings ...) call to load a configuration state"
      []
      (let [ns (the-ns 'speclj.config)
@@ -101,10 +101,10 @@
 
 
    :cljs
-   (defn config-mappings [_] (throw "Not Supportedin ClojureScript")))
+   (defn config-mappings [_] (throw "Not Supported in ClojureScript")))
 
 (defn with-config
-  "Runs the given function with all the cofigurations set.  Useful in cljs because config-mappings can't be used."
+  "Runs the given function with all the configurations set.  Useful in cljs because config-mappings can't be used."
   [config action]
   (binding [*runner* (if (:runner config) (do (println "loading runner in config") (load-runner (:runner config))) (active-runner))
             *reporters* (if (:reporters config) (mapv load-reporter (:reporters config)) (active-reporters))

--- a/src/speclj/core.cljc
+++ b/src/speclj/core.cljc
@@ -1,5 +1,5 @@
 (ns speclj.core
-  "Speclj's API.  It contains nothing but macros, so that it can be used
+  "Speclj's API. It contains nothing but macros, so that it can be used
   in both Clojure and ClojureScript."
   (:require [clojure.data]
             [speclj.components]
@@ -56,7 +56,7 @@
 (defmacro describe
   "body => & spec-components
 
-  Declares a new spec.  The body can contain any forms that evaluate to spec compoenents (it, before, after, with ...)."
+  Declares a new spec.  The body can contain any forms that evaluate to spec components (it, before, after, with ...)."
   [name & components]
   `(let [description# (speclj.components/new-description ~name ~(clojure.core/name (.name *ns*)))]
      (binding [speclj.config/*parent-description* description#]
@@ -93,7 +93,7 @@
 
   (around [it] (binding [*out* new-out] (it)))
 
-  Note that if you have cleanup that must run, use a finally block:
+  Note that if you have cleanup that must run, use a 'finally' block:
 
   (around [it] (try (it) (finally :clean-up)))
   "
@@ -228,7 +228,7 @@
        (-fail (str "Expected " (-to-s actual#) " not to satisfy: " ~(str f-form))))))
 
 (defmacro should-not=
-  "Asserts that two forms evaluate to inequal values, with the unexpected value as the first parameter."
+  "Asserts that two forms evaluate to unequal values, with the unexpected value as the first parameter."
   [expected-form actual-form]
   `(let [expected# ~expected-form actual# ~actual-form]
      (when (= expected# actual#)
@@ -254,7 +254,7 @@
   `(should= nil ~form))
 
 (defmacro should-contain
-  "Multi-purpose assertion of containment.  Works strings, regular expressions, sequences, and maps.
+  "Multi-purpose assertion of containment.  Works on strings, regular expressions, sequences, and maps.
 
   (should-contain \"foo\" \"foobar\")            ; looks for sub-string
   (should-contain #\"hello.*\" \"hello, world\") ; looks for regular expression
@@ -383,7 +383,7 @@
 
 (defmacro should-throw
   "Asserts that a Throwable is throws by the evaluation of a form.
-When an class is passed, it assets that the thrown Exception is an instance of the class.
+When an class is passed, it asserts that the thrown Exception is an instance of the class.
 There are three options for passing different kinds of predicates:
   - If a string, assert that the message of the Exception is equal to the string.
   - If a regex, asserts that the message of the Exception matches the regex.
@@ -433,7 +433,7 @@ There are three options for passing different kinds of predicates:
        (-fail (str "Expected " (-to-s actual#) " to be an instance of: " (-to-s expected-type#) speclj.platform/endl "           but was an instance of: " (-to-s actual-type#) " (using isa?)")))))
 
 (defmacro should-not-be-a
-  "Asserts that the type of the given form does not derives from or equals the expected type"
+  "Asserts that the type of the given form does not derived from or equals the expected type"
   [expected-type actual-form]
   `(let [actual# ~actual-form
          actual-type# (type actual#)
@@ -442,7 +442,7 @@ There are three options for passing different kinds of predicates:
        (-fail (str "Expected " (-to-s actual#) " not to be an instance of " (-to-s expected-type#) " but was (using isa?)")))))
 
 (defmacro pending
-  "When added to a characteristic, it is markes as pending.  If a message is provided it will be printed
+  "When added to a characteristic, it is marked as pending.  If a message is provided it will be printed
   in the run report"
   ([] `(pending "Not Yet Implemented"))
   ([message]
@@ -469,8 +469,8 @@ There are three options for passing different kinds of predicates:
 
   Options:
     :invoke - a function that will be invoked when the stub is invoked.  All the arguments passed to the stub will
-      be passed to the :invoke value and it's return value returned by the stub.
-    :return - a value that will be returned by the stub.  This overides the result of the :invoke value, if specified.
+      be passed to the :invoke value and its return value returned by the stub.
+    :return - a value that will be returned by the stub.  This overrides the result of the :invoke value, if specified.
     :throw - an exception that will be thrown by the stub."
   ([name] `(speclj.stub/stub ~name {}))
   ([name options] `(speclj.stub/stub ~name ~options)))
@@ -634,9 +634,9 @@ There are three options for passing different kinds of predicates:
 
 
 (defmacro run-specs []
-  "If evaluated outsite the context of a spec run, it will run all the specs that have been evaulated using the default
+  "If evaluated outside the context of a spec run, it will run all the specs that have been evaluated using the default
 runner and reporter.  A call to this function is typically placed at the end of a spec file so that all the specs
-are evaluated by evaluation the file as a script.  Optional configuration paramters may be passed in:
+are evaluated by evaluation the file as a script.  Optional configuration parameters may be passed in:
 
 (run-specs :stacktrace true :color false :reporter \"documentation\")"
   `(if-cljs

--- a/src/speclj/report/documentation.cljc
+++ b/src/speclj/report/documentation.cljc
@@ -1,9 +1,8 @@
 (ns speclj.report.documentation
-  (:require [speclj.config :refer [default-reporters]]
-            [speclj.platform :refer [endl error-message failure-source]]
+  (:require [speclj.components :refer [focused?]]
+            [speclj.platform :refer [error-message]]
             [speclj.report.progress :refer [print-summary]]
-            [speclj.reporting :refer [tally-time green red yellow indent]]
-            [speclj.results :refer [pass? fail?]]))
+            [speclj.reporting :refer [green indent red yellow]]))
 
 (defn level-of [component]
   (loop [component @(.-parent component) level 0]
@@ -21,16 +20,18 @@
       (println (str (indent level (.-name description)))) (flush)))
   (report-pass [this result]
     (let [characteristic (.-characteristic result)
-          level (level-of characteristic)]
-      (println (green (indent (dec level) "- " (.-name characteristic)))) (flush)))
+          level          (level-of characteristic)]
+      (print (green (indent (dec level) "- " (.-name characteristic))))
+      (when (focused? characteristic) (print (str " " (yellow "[FOCUS]")))) (println) (flush)))
   (report-pending [this result]
     (let [characteristic (.-characteristic result)
-          level (level-of characteristic)]
+          level          (level-of characteristic)]
       (println (yellow (indent (dec level) "- " (.-name characteristic) " (PENDING: " (error-message (.-exception result)) ")"))) (flush)))
   (report-fail [this result]
     (let [characteristic (.-characteristic result)
-          level (level-of characteristic)]
-      (println (red (indent (dec level) "- " (.-name characteristic) " (FAILED)"))) (flush)))
+          level          (level-of characteristic)]
+      (print (red (indent (dec level) "- " (.-name characteristic) " (FAILED)")))
+      (when (focused? characteristic) (print (str " " (yellow "[FOCUS]")))) (println) (flush)))
   (report-error [this result]
     (println (red (.toString (.-exception result)))))
   (report-runs [this results]

--- a/src/speclj/run/standard.cljs
+++ b/src/speclj/run/standard.cljs
@@ -45,9 +45,9 @@
 (def armed false)
 
 (defn run-specs [& configurations]
-  "If evaluated outsite the context of a spec run, it will run all the specs that have been evaulated using the default
+  "If evaluated outside the context of a spec run, it will run all the specs that have been evaluated using the default
 runner and reporter.  A call to this function is typically placed at the end of a spec file so that all the specs
-are evaluated by evaluation the file as a script.  Optional configuration paramters may be passed in:
+are evaluated by evaluation the file as a script.  Optional configuration parameters may be passed in:
 
 (run-specs :stacktrace true :color false :reporters [\"documentation\"])"
   (when armed

--- a/src/speclj/run/vigilant.clj
+++ b/src/speclj/run/vigilant.clj
@@ -1,23 +1,22 @@
 (ns speclj.run.vigilant
   (:require [clojure.java.io :refer [file]]
-            [fresh.core :refer [freshener make-fresh ns-to-file clj-files-in]]
-            [speclj.config :refer [active-runner active-reporters config-bindings *specs*]]
-            [speclj.platform :refer [endl secs-since format-seconds current-time enter-pressed?]]
-            [speclj.reporting :refer [report-runs* report-message* report-error*]]
+            [fresh.core :refer [clj-files-in make-fresh ns-to-file]]
+            [speclj.config :refer [active-reporters active-runner config-bindings]]
+            [speclj.platform :refer [current-time endl enter-pressed? format-seconds secs-since]]
+            [speclj.reporting :refer [report-message* report-runs*]]
             [speclj.results :refer [categorize]]
-            [speclj.running :refer [do-description run-and-report run-description process-compile-error]])
-  (:import [speclj.running Runner]
-           [java.util.concurrent ScheduledThreadPoolExecutor TimeUnit]))
+            [speclj.running :refer [do-description filter-focused process-compile-error run-and-report run-description]])
+  (:import (java.util.concurrent ScheduledThreadPoolExecutor TimeUnit)
+           (speclj.running Runner)))
 
 (def start-time (atom 0))
 
 (defn- ns-for-results [results]
-  (set (map #(str (.ns @(.. % characteristic parent))) results))
-  )
+  (set (map #(str (.ns @(.. % characteristic parent))) results)))
 
 (defn- report-update [report]
   (let [reporters (active-reporters)
-        reloads (:reloaded report)]
+        reloads   (:reloaded report)]
     (when (seq reloads)
       (report-message* reporters (str endl "----- " (str (java.util.Date.) " -----")))
       (report-message* reporters (str "took " (format-seconds (secs-since @start-time)) " to determine file statuses."))
@@ -27,33 +26,30 @@
 
 (defn- reload-files [runner current-results]
   (let [previous-failed-files (map ns-to-file (ns-for-results @(.previous-failed runner)))
-        files-to-reload (set (concat previous-failed-files current-results))]
+        files-to-reload       (set (concat previous-failed-files current-results))]
     (swap! (.file-listing runner) #(apply dissoc % previous-failed-files))
-    (make-fresh (.file-listing runner) files-to-reload report-update)
-    )
-  )
+    (make-fresh (.file-listing runner) files-to-reload report-update)))
 
 (defn- reload-report [runner report]
   (let [reloads (:reloaded report)]
     (when (seq reloads)
-      (reload-files runner reloads)
-      )
-    )
+      (reload-files runner reloads)))
   false)
 
 (defn- tick [configuration]
   (with-bindings configuration
-    (let [runner (active-runner)
+    (let [runner    (active-runner)
           reporters (active-reporters)]
       (try
         (reset! start-time (current-time))
         (make-fresh (.file-listing runner) (set (apply clj-files-in @(.directories runner))) (partial reload-report runner))
-        (when (seq @(.results runner))
+        (when (seq @(.descriptions runner))
           (reset! (.previous-failed runner) (:fail (categorize (seq @(.results runner)))))
           (run-and-report runner reporters))
         (catch java.lang.Throwable e
           (process-compile-error runner e)
           (report-runs* reporters @(.results runner))))
+      (reset! (.descriptions runner) [])
       (reset! (.results runner) []))))
 
 (defn- reset-runner [runner]
@@ -66,13 +62,13 @@
     (when (enter-pressed?)
       (reset-runner (active-runner)))))
 
-(deftype VigilantRunner [file-listing results previous-failed directories]
+(deftype VigilantRunner [file-listing results previous-failed directories descriptions]
   Runner
   (run-directories [this directories reporters]
-    (let [scheduler (ScheduledThreadPoolExecutor. 1)
+    (let [scheduler     (ScheduledThreadPoolExecutor. 1)
           configuration (config-bindings)
-          runnable (fn [] (tick configuration))
-          dir-files (map file directories)]
+          runnable      (fn [] (tick configuration))
+          dir-files     (map file directories)]
       (reset! (.directories this) dir-files)
       (.scheduleWithFixedDelay scheduler runnable 0 500 TimeUnit/MILLISECONDS)
       (.scheduleWithFixedDelay scheduler (fn [] (listen-for-rerun configuration)) 0 500 TimeUnit/MILLISECONDS)
@@ -80,18 +76,16 @@
       0))
 
   (submit-description [this description]
-    (run-description this description (active-reporters)))
+    (swap! descriptions conj description))
 
   (run-description [this description reporters]
     (let [run-results (do-description description reporters)]
       (swap! results into run-results)))
 
   (run-and-report [this reporters]
-    (report-runs* reporters @results))
-
-;  Object
-;  (toString [this] (str this))
-  )
+    (doseq [description (filter-focused @descriptions)]
+      (run-description this description reporters))
+    (report-runs* reporters @results)))
 
 (defn new-vigilant-runner []
-  (VigilantRunner. (atom {}) (atom []) (atom []) (atom nil)))
+  (VigilantRunner. (atom {}) (atom []) (atom []) (atom nil) (atom [])))

--- a/src/speclj/run/vigilant.clj
+++ b/src/speclj/run/vigilant.clj
@@ -19,7 +19,7 @@
   (let [reporters (active-reporters)
         reloads (:reloaded report)]
     (when (seq reloads)
-      (report-message* reporters (str endl "----- " (str (java.util.Date.) " -------------------------------------------------------------------")))
+      (report-message* reporters (str endl "----- " (str (java.util.Date.) " -----")))
       (report-message* reporters (str "took " (format-seconds (secs-since @start-time)) " to determine file statuses."))
       (report-message* reporters "reloading files:")
       (doseq [file reloads] (report-message* reporters (str "  " (.getCanonicalPath file))))))

--- a/src/speclj/running.cljc
+++ b/src/speclj/running.cljc
@@ -1,11 +1,17 @@
 (ns speclj.running
   (:require [clojure.string :as str]
-            [speclj.components :refer [reset-with]]
-            [speclj.config :refer [*runner* active-reporters]]
-            [speclj.platform :refer [pending? throwable secs-since current-time]]
-            [speclj.reporting :refer [report-runs* report-run report-description*]]
-            [speclj.results :refer [pass-result fail-result pending-result error-result]]
-            [speclj.tags :refer [tags-for tag-sets-for pass-tag-filter? context-with-tags-seq]]))
+            [speclj.components :refer [focused? reset-with]]
+            [speclj.config :refer [active-reporters]]
+            [speclj.platform :refer [current-time pending? secs-since]]
+            [speclj.reporting :refer [report-description* report-run]]
+            [speclj.results :refer [error-result fail-result pass-result pending-result]]
+            [speclj.tags :refer [pass-tag-filter? tag-sets-for tags-for]]))
+
+(defn filter-focused [descriptions]
+  (or (seq (filter focused? descriptions)) descriptions))
+
+(defn filter-focused-children [component children]
+  (if-not (focused? component) children (filter focused? children)))
 
 (defn- eval-components [components]
   (doseq [component components] ((.-body component))))
@@ -33,27 +39,25 @@
 
 (defn- report-result [result-constructor characteristic start-time reporters failure]
   (let [present-args (filter identity [characteristic (secs-since start-time) failure])
-        result (apply result-constructor present-args)]
+        result       (apply result-constructor present-args)]
     (report-run result reporters)
     result))
 
 (defn- do-characteristic [characteristic reporters]
-  (let [description @(.-parent characteristic)
-        befores (collect-components #(deref (.-befores %)) description)
-        afters (collect-components #(deref (.-afters %)) description)
-        core-body (.-body characteristic)
+  (let [description           @(.-parent characteristic)
+        befores               (collect-components #(deref (.-befores %)) description)
+        afters                (collect-components #(deref (.-afters %)) description)
+        core-body             (.-body characteristic)
         before-and-after-body (fn [] (eval-characteristic befores core-body afters))
-        arounds (collect-components #(deref (.-arounds %)) description)
-        full-body (nested-fns before-and-after-body (map #(.-body %) arounds))
-        withs (collect-components #(deref (.-withs %)) description)
-        start-time (current-time)]
+        arounds               (collect-components #(deref (.-arounds %)) description)
+        full-body             (nested-fns before-and-after-body (map #(.-body %) arounds))
+        withs                 (collect-components #(deref (.-withs %)) description)
+        start-time            (current-time)]
     (try
       (do
         (full-body)
         (report-result pass-result characteristic start-time reporters nil))
-      (catch #?(:clj  java.lang.Throwable
-                :cljs :default)
-             e
+      (catch #?(:clj java.lang.Throwable :cljs :default) e
         (if (pending? e)
           (report-result pending-result characteristic start-time reporters e)
           (report-result fail-result characteristic start-time reporters e)))
@@ -68,30 +72,31 @@
 (declare do-description)
 
 (defn- do-child-contexts [context results reporters]
-  (loop [results results contexts @(.-children context)]
-    (if (seq contexts)
-      (recur (concat results (do-description (first contexts) reporters)) (rest contexts))
+  (loop [results  results
+         children (filter-focused-children context @(.-children context))]
+    (if (seq children)
+      (recur (concat results (do-description (first children) reporters)) (rest children))
       (do
         (eval-components @(.-after-alls context))
         results))))
 
 (defn- results-for-context [context reporters]
   (if (pass-tag-filter? (tags-for context))
-    (do-characteristics @(.-characteristics context) reporters)
+    (do-characteristics (filter-focused-children context @(.-characteristics context)) reporters)
     []))
 
 #?(:clj
    (defn- with-withs-bound [description body]
-     (let [withs (concat @(.-withs description) @(.-with-alls description))
-           ns (the-ns (symbol (.-ns description)))
+     (let [withs         (concat @(.-withs description) @(.-with-alls description))
+           ns            (the-ns (symbol (.-ns description)))
            with-mappings (reduce #(assoc %1 (ns-resolve ns (.-name %2)) %2) {} withs)]
        (with-bindings* with-mappings body)))
 
    :cljs
    (defn- with-withs-bound [description body]
-     (let [withs (concat @(.-withs description) @(.-with-alls description))
-           ns (str/replace (.-ns description) "-" "_")
-           var-names (map #(str ns "." (name (.-name %))) withs)
+     (let [withs        (concat @(.-withs description) @(.-with-alls description))
+           ns           (str/replace (.-ns description) "-" "_")
+           var-names    (map #(str ns "." (name (.-name %))) withs)
            unique-names (map #(str ns "." (name (.-unique-name %))) withs)]
        (doseq [[n un] (partition 2 (interleave var-names unique-names))]
          (let [code (str n " = " un ";")]

--- a/src/speclj/running.cljc
+++ b/src/speclj/running.cljc
@@ -77,7 +77,7 @@
 
 (defn- results-for-context [context reporters]
   (if (pass-tag-filter? (tags-for context))
-    (do-characteristics @(.-charcteristics context) reporters)
+    (do-characteristics @(.-characteristics context) reporters)
     []))
 
 #?(:clj


### PR DESCRIPTION
Meant to facilitate temporary debugging, characteristics defined with the `focus-it` macro will be executed along with any other characteristics thus defined, but all other characteristics defined with `it` will be ignored.