### PR TITLE
Adds cloverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Clone the master branch, build, and run all the tests:
 ```bash
 $ git clone https://github.com/slagyr/speclj.git
 $ cd speclj
+$ clj -T:build javac
 $ clj -M:test:spec
 ```
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,7 @@
            mmargs/mmargs        {:mvn/version "1.2.0"}
            org.clojure/clojure  {:mvn/version "1.11.1"}
            trptcolin/versioneer {:mvn/version "0.1.1"}
+           cloverage/cloverage  {:mvn/version "1.2.4"}
            }
  :aliases {
            :test  {:extra-deps  {

--- a/src/speclj/cloverage.clj
+++ b/src/speclj/cloverage.clj
@@ -1,0 +1,19 @@
+(ns speclj.cloverage
+  (:require [cloverage.coverage :as coverage]
+            [speclj.config :refer [*reporters* *runner*]]
+            [speclj.report.documentation]
+            [speclj.results :as results]
+            [speclj.run.standard]
+            [speclj.running :refer [run-and-report]])
+  (:import (speclj.report.documentation DocumentationReporter)
+           (speclj.run.standard StandardRunner)))
+
+(defmethod coverage/runner-fn :speclj [_opts]
+  (fn [nses]
+    (let [results (atom [])
+          runner (StandardRunner. (atom []) results)
+          reporters [(DocumentationReporter.)]]
+      (binding [*runner* runner *reporters* reporters]
+        (apply require (map symbol nses))
+        (run-and-report runner reporters))
+      {:errors (results/fail-count @results)})))


### PR DESCRIPTION
To add code coverage using [cloverage](https://github.com/cloverage/cloverage/), you can specify --runner=:speclj when running cloverage.