### PR TITLE
Fixes failing cljr tests

### DIFF
--- a/dev/speclj/script/install_cljr.bb
+++ b/dev/speclj/script/install_cljr.bb
@@ -5,7 +5,7 @@
             [speclj.script.util :as util]))
 
 (defn -main [& args]
-  (util/dotnet-tool-install "Clojure.Main" "1.12.0-alpha10")
-  (util/dotnet-tool-install "Clojure.Cljr" "0.1.0-alpha5"))
+  (util/dotnet-tool-install "Clojure.Main" "1.12.3-alpha4")
+  (util/dotnet-tool-install "Clojure.Cljr" "0.1.0-alpha10"))
 
 (script/when-main)

--- a/spec/bb/speclj/script/install_cljr_spec.bb
+++ b/spec/bb/speclj/script/install_cljr_spec.bb
@@ -9,9 +9,9 @@
 
   (it "installs Clojure.Main"
     (sut/-main)
-    (should-have-invoked :shell/sh {:with ["dotnet" "tool" "install" "--global" "Clojure.Main" "--version" "1.12.0-alpha10"]}))
+    (should-have-invoked :shell/sh {:with ["dotnet" "tool" "install" "--global" "Clojure.Main" "--version" "1.12.3-alpha4"]}))
 
   (it "installs Clojure.Cljr"
     (sut/-main)
-    (should-have-invoked :shell/sh {:with ["dotnet" "tool" "install" "--global" "Clojure.Cljr" "--version" "0.1.0-alpha5"]}))
+    (should-have-invoked :shell/sh {:with ["dotnet" "tool" "install" "--global" "Clojure.Cljr" "--version" "0.1.0-alpha10"]}))
   )

--- a/spec/cljc/speclj/platform_spec.cljc
+++ b/spec/cljc/speclj/platform_spec.cljc
@@ -7,6 +7,13 @@
 (defmacro which-env []
   (if-cljs :cljs :clj))
 
+(defmacro result-or-ex [& body]
+  `(try (do ~@body)
+        (catch #?(:cljs :default
+                  :cljr Exception
+                  :default Throwable)
+               e# e#)))
+
 (defmacro current-line
   "Macroexpands to the line number of the call site under bb/JVM. Returns nil
    under cljs because same-file defmacros don't receive a useful &form there.
@@ -33,8 +40,7 @@
 (defn caught
   "Evaluates `thunk` and returns the thrown exception, or nil if nothing is thrown."
   [thunk]
-  (try (thunk) nil
-       (catch #?(:cljs :default :default Throwable) e e)))
+  (result-or-ex (thunk) nil))
 
 (describe "platform-specific bits"
   #?(:cljs
@@ -87,8 +93,7 @@
     ;; that over the JVM/sci stack trace, otherwise babashka users see
     ;; sci/lang/Var.clj instead of their own source line.
     (let [base (current-line ::mark)
-          ex   (try (should= 1 2)        ; line = base + 1
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (should= 1 2))   ; line = base + 1
           d    (ex-data ex)]
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))
       (should-contain "speclj/platform_spec" (sut/failure-source-str ex))))
@@ -97,8 +102,7 @@
     ;; The pending macro embeds its &form loc directly in the ex-info; without
     ;; this, babashka users see sci/lang/Var.clj instead of the pending line.
     (let [base (current-line ::mark)
-          ex   (try (speclj.core/pending "TODO")  ; line = base + 1
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (speclj.core/pending "TODO"))   ; line = base + 1
           d    (ex-data ex)]
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))
       (should-contain "speclj/platform_spec" (sut/failure-source-str ex))))
@@ -132,23 +136,20 @@
     ;; The propagated meta is what makes should=' &form see the user's
     ;; should-be-nil call site instead of the syntax-generated form.
     (let [base (current-line ::mark)
-          ex   (try (should-be-nil 42)   ; line = base + 1
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (should-be-nil 42))   ; line = base + 1
           d    (ex-data ex)]
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))))
 
   (it "delegating should-not-be-nil reports its own call site"
     (let [base (current-line ::mark)
-          ex   (try (should-not-be-nil nil)   ; line = base + 1
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (should-not-be-nil nil))   ; line = base + 1
           d    (ex-data ex)]
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))))
 
   (it "0-arg should-fail propagates loc to the 1-arg arity"
     ;; (should-fail) is the (with-meta `(should-fail "Forced failure") ...) path.
     (let [base (current-line ::mark)
-          ex   (try (should-fail)        ; line = base + 1
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (should-fail))   ; line = base + 1
           d    (ex-data ex)]
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))))
 
@@ -158,8 +159,7 @@
     ;; merges *source-loc* (bound by the surrounding help-should) into ex-data.
     ;; This is the only path that exercises -new-failure rather than -fail.
     (let [base (current-line ::mark)
-          ex   (try (should-throw sut/throwable :nothing-thrown)  ; line = base + 1
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (should-throw sut/throwable :nothing-thrown))   ; line = base + 1
           d    (ex-data ex)]
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))))
 
@@ -168,10 +168,9 @@
     ;; so the inner should=/should-not-be-nil delegations report the user's
     ;; should-throw call site rather than nothing at all.
     (let [base (current-line ::mark)
-          ex   (try (should-throw sut/throwable
-                                  #"completely-different-message"
-                                  (throw (ex-info "actual" {})))   ; line = base + 3
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (should-throw sut/throwable
+                                           #"completely-different-message"
+                                           (throw (ex-info "actual" {}))))   ; line = base + 3
           d    (ex-data ex)]
       ;; The wrapped body's location is the should-throw line itself (base+1),
       ;; because with-source-loc binds *source-loc* at expansion of should-throw.
@@ -182,8 +181,7 @@
     ;; When called outside a help-should wrapper, *source-loc* is unbound, so
     ;; -fail must rely on its own (meta &form) to embed file/line.
     (let [base (current-line ::mark)
-          ex   (try (speclj.core/-fail "boom")    ; line = base + 1
-                    (catch #?(:cljs :default :default Throwable) e e))
+          ex   (result-or-ex (speclj.core/-fail "boom"))   ; line = base + 1
           d    (ex-data ex)]
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))))
 
@@ -194,8 +192,7 @@
     (let [base    (current-line ::mark)
           chr     (it "auto-pending sentinel")    ; line = base + 1
           body-fn (.-body chr)
-          ex      (try (body-fn) nil
-                       (catch #?(:cljs :default :default Throwable) e e))
+          ex      (result-or-ex (body-fn) nil)
           d       (ex-data ex)]
       (should-not-be-nil ex)
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))))
@@ -204,8 +201,7 @@
     (let [base    (current-line ::mark)
           chr     (xit "skipped sentinel")        ; line = base + 1
           body-fn (.-body chr)
-          ex      (try (body-fn) nil
-                       (catch #?(:cljs :default :default Throwable) e e))
+          ex      (result-or-ex (body-fn) nil)
           d       (ex-data ex)]
       (should-not-be-nil ex)
       (assert-loc-at d #?(:cljs :any :default (+ base 1)))))

--- a/src/clj/speclj/io.clj
+++ b/src/clj/speclj/io.clj
@@ -3,6 +3,8 @@
   (:import (clojure.lang LineNumberingPushbackReader)
            (java.io File StringReader StringWriter)))
 
+(def file-separator java.io.File/separator)
+
 (defn as-file
   ([parent child] (io/file parent child))
   ([file] (io/as-file file)))
@@ -15,6 +17,7 @@
 (defn exists? [file] (.exists file))
 (defn parent-file [file] (.getParentFile file))
 (defn delete [file] (io/delete-file file))
+(defn directory? [file] (.isDirectory file))
 
 (defn ->LineNumberingReader [reader] (LineNumberingPushbackReader. reader))
 (defn ->StringReader [s] (StringReader. s))

--- a/src/cljc/speclj/cli.cljc
+++ b/src/cljc/speclj/cli.cljc
@@ -1,7 +1,7 @@
 (ns speclj.cli
   (:require #?(:clj [trptcolin.versioneer.core :as version])
             #?@(:cljs    []
-                :default [[clojure.java.io :as jio]])
+                :default [[speclj.io :as io]])
             [speclj.args :as args]
             [clojure.set :as set]
             [speclj.config :as config]
@@ -104,7 +104,7 @@
 
 (defn- dir-path? [p]
   #?(:cljs false
-     :default (try (.isDirectory (jio/as-file p))
+     :default (try (-> p io/as-file io/directory?)
                    (catch #?(:cljr Exception :default Exception) _ false))))
 
 (defn- covers-file?
@@ -115,11 +115,11 @@
   #?(:cljs false
      :default
      (try
-       (let [t (.getCanonicalPath (jio/as-file target))
-             b (.getCanonicalPath (jio/as-file bare))]
+       (let [t (-> target io/as-file io/canonical-path)
+             b (-> bare io/as-file io/canonical-path)]
          (if (dir-path? bare)
            (or (= t b)
-               (clojure.string/starts-with? t (str b (java.io.File/separator))))
+               (clojure.string/starts-with? t (str b io/file-separator)))
            (= t b)))
        (catch #?(:cljr Exception :default Exception) _ false))))
 
@@ -176,7 +176,7 @@
 
 (defn- path-exists? [path]
   #?(:cljs true
-     :default (try (.exists (jio/as-file path))
+     :default (try (-> path io/as-file io/exists?)
                    (catch #?(:cljr Exception :default Exception) _ true))))
 
 (defn- prune-missing-targets

--- a/src/cljr/speclj/io.cljr
+++ b/src/cljr/speclj/io.cljr
@@ -1,7 +1,9 @@
 (ns speclj.io
   (:require [clojure.clr.io :as io])
-  (:import (System.IO Directory File DirectoryInfo FileAttributes StringReader StringWriter)
+  (:import (System.IO Directory File Path DirectoryInfo FileAttributes StringReader StringWriter)
            (clojure.lang LineNumberingTextReader)))
+
+(def file-separator Path/DirectorySeparatorChar)
 
 (defn as-file
   ([parent child] (io/file-info parent child))
@@ -21,7 +23,8 @@
 
 (defn file-name [file] (.-Name file))
 (defn full-name [file] (.-FullName file))
-(defn exists? [file] (or (.-Exists file) (Directory/Exists (full-name file))))
+(defn directory? [file] (Directory/Exists (full-name file)))
+(defn exists? [file] (or (.-Exists file) (directory? file)))
 (defn parent-file [file] (.-Directory file))
 (defn delete [file] (File/Delete (str file)))
 


### PR DESCRIPTION
This PR makes some progress in fixing ClojureCLR support, but a couple gaps still exist:
1. ClojureCLR's implementation of `speclj.platform` `failure-source` and `failure-source-str` is causing a few test failures
2. Both ClojureCLR and Clojure JVM have a few failing tests when run with the `-a` flag in `speclj.run.standard-spec` `"StandardRunner line-filter integration ..."`